### PR TITLE
Refactor the animation activity

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -5,7 +5,6 @@
       <module fileurl="file://$PROJECT_DIR$/Adamastor.iml" filepath="$PROJECT_DIR$/Adamastor.iml" />
       <module fileurl="file://$PROJECT_DIR$/adamastor.iml" filepath="$PROJECT_DIR$/adamastor.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/corp/kairos/adamastor/AllApps/AllAppsActivity.java
+++ b/app/src/main/java/corp/kairos/adamastor/AllApps/AllAppsActivity.java
@@ -16,12 +16,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import corp.kairos.adamastor.AnimActivity;
+import corp.kairos.adamastor.HomeActivity;
 import corp.kairos.adamastor.R;
 
 import static corp.kairos.adamastor.Util.getObjectByIndex;
 
-
-public class AllAppsActivity extends Activity {
+public class AllAppsActivity extends AnimActivity {
     private PackageManager packageManager;
     private Set<AppDetail> allApps;
     private GridView allAppsMenuView;
@@ -30,6 +31,8 @@ public class AllAppsActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.allapps_menu);
+
+        this.setLeftActivity(HomeActivity.class);
 
         loadApps();
         loadListView();
@@ -69,54 +72,5 @@ public class AllAppsActivity extends Activity {
                 AllAppsActivity.this.startActivity(i);
             }
         });
-    }
-
-
-    @Override
-    public void finish() {
-        super.finish();
-        overridePendingTransitionExit();
-    }
-
-    @Override
-    public void startActivity(Intent intent) {
-        super.startActivity(intent);
-        overridePendingTransitionEnter();
-    }
-
-    protected void overridePendingTransitionEnter() {
-        overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
-    }
-
-    protected void overridePendingTransitionExit() {
-        overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
-    }
-
-    private float x1;
-    private float x2;
-    private float MIN_DISTANCE = 200;
-    @Override
-    public boolean onTouchEvent(MotionEvent event)
-    {
-        switch(event.getAction())
-        {
-            case MotionEvent.ACTION_DOWN:
-                x1 = event.getX();
-                break;
-            case MotionEvent.ACTION_UP:
-                x2 = event.getX();
-                float deltaX = x2 - x1;
-                if (deltaX > MIN_DISTANCE) {
-                    onBackPressed();
-                }
-                break;
-        }
-        return super.onTouchEvent(event);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        overridePendingTransitionExit();
     }
 }

--- a/app/src/main/java/corp/kairos/adamastor/AnimActivity.java
+++ b/app/src/main/java/corp/kairos/adamastor/AnimActivity.java
@@ -1,0 +1,99 @@
+package corp.kairos.adamastor;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.util.Log;
+import android.view.MotionEvent;
+
+
+public abstract class AnimActivity extends Activity {
+
+    private float x1;
+    private float x2;
+    private float MIN_DISTANCE = 300;
+
+    private Class rightActivity;
+    private Class leftActivity;
+    private String animation;
+
+    public Class getRightActivity() {
+        return rightActivity;
+    }
+
+    public void setRightActivity(Class rightActivity) {
+        this.rightActivity = rightActivity;
+    }
+
+    public Class getLeftActivity() {
+        return leftActivity;
+    }
+
+    public void setLeftActivity(Class leftActivity) {
+        this.leftActivity = leftActivity;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event)
+    {
+        switch(event.getAction())
+        {
+            case MotionEvent.ACTION_DOWN:
+                x1 = event.getX();
+                break;
+            case MotionEvent.ACTION_UP:
+                x2 = event.getX();
+                float deltaX1 = x1 - x2;
+                if (deltaX1 > MIN_DISTANCE) {
+                    if(this.rightActivity != null) {
+                        this.animation = "right";
+                        startActivity(rightActivity);
+                    }
+                } else {
+                    float deltaX2 = x2 - x1;
+                    if (deltaX2 > MIN_DISTANCE) {
+                        if(this.leftActivity != null) {
+                            this.animation = "left";
+                            startActivity(leftActivity);
+                        }
+                    }
+                }
+                break;
+        }
+        return super.onTouchEvent(event);
+    }
+
+    protected void startActivity(Class activity){
+        Intent i = new Intent(this, activity);
+        startActivity(i);
+    }
+
+    @Override
+    public void startActivity(Intent intent) {
+        super.startActivity(intent);
+        if(this.animation == "right") {
+            overridePendingTransitionRight();
+        } else {
+            overridePendingTransitionLeft();
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        overridePendingTransitionLeft();
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
+        overridePendingTransitionLeft();
+    }
+
+    private void overridePendingTransitionRight() {
+        overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
+    }
+
+    private void overridePendingTransitionLeft() {
+        overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
+    }
+}

--- a/app/src/main/java/corp/kairos/adamastor/HomeActivity.java
+++ b/app/src/main/java/corp/kairos/adamastor/HomeActivity.java
@@ -32,24 +32,9 @@ import corp.kairos.adamastor.AllApps.AllAppsActivity;
 import corp.kairos.adamastor.AllApps.AppDetail;
 import corp.kairos.adamastor.R;
 
-public class HomeActivity extends Activity {
+public class HomeActivity extends AnimActivity {
 
     private static final String TAG = HomeActivity.class.getName();
-
-    private long mCurrentMillis;
-    private float mVelocity;
-
-    /**
-     * The time constant used to calculate dampening in the low-pass filter of scroll velocity.
-     * Cutoff frequency is set at 10 Hz.
-     */
-    public static final float SCROLL_VELOCITY_DAMPENING_RC = 1000f / (2f * (float) Math.PI * 10);
-    private float mLastY;
-    private float mDownX;
-    private float mDownY;
-    private int mLastDisplacement;
-    private float mDisplacementY;
-    private float mDisplacementX;
 
     private UserContext currentContext;
     private int currentContextIndex;
@@ -65,6 +50,7 @@ public class HomeActivity extends Activity {
         setContexts();
         this.currentContext = this.contexts[0];
         this.currentContextIndex = 0;
+        this.setRightActivity(AllAppsActivity.class);
 
         addClickListener();
     }
@@ -152,60 +138,12 @@ public class HomeActivity extends Activity {
         }
     }
 
-    @Override
-    public void finish() {
-        super.finish();
-        overridePendingTransitionExit();
-    }
-
-    @Override
-    public void startActivity(Intent intent) {
-        super.startActivity(intent);
-        overridePendingTransitionEnter();
-    }
-
-    protected void overridePendingTransitionEnter() {
-        overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
-    }
-
-    protected void overridePendingTransitionExit() {
-        overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        overridePendingTransitionExit();
-    }
 
     public void showAllAppsMenu(View v){
         Vibrator vibe = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
         vibe.vibrate(50);
         Intent i = new Intent(this, AllAppsActivity.class);
         startActivity(i);
-    }
-
-    private float x1;
-    private float x2;
-    private float MIN_DISTANCE = 200;
-    @Override
-    public boolean onTouchEvent(MotionEvent event)
-    {
-        switch(event.getAction())
-        {
-            case MotionEvent.ACTION_DOWN:
-                x1 = event.getX();
-                break;
-            case MotionEvent.ACTION_UP:
-                x2 = event.getX();
-                float deltaX = x1 - x2;
-                if (deltaX > MIN_DISTANCE) {
-                    Intent i = new Intent(this, AllAppsActivity.class);
-                    startActivity(i);
-                }
-                break;
-        }
-        return super.onTouchEvent(event);
     }
 
     /*

--- a/app/src/main/res/layout/allapps_app.xml
+++ b/app/src/main/res/layout/allapps_app.xml
@@ -23,5 +23,8 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:gravity="center"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="11dp"
         android:textColor="@color/appLabelText" />
 </LinearLayout>

--- a/app/src/main/res/layout/allapps_menu.xml
+++ b/app/src/main/res/layout/allapps_menu.xml
@@ -12,7 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fadingEdge="none"
-        android:numColumns="auto_fit"
+        android:numColumns="4"
         android:columnWidth="100dp"
         android:verticalSpacing="5dp"
         android:horizontalSpacing="5dp"


### PR DESCRIPTION
This MR adds a simpler way to animate activities and for an activity to launch a new activity by swipe left or right.

For an activity to be animated it should extend the class `AnimActivity` which in turn extends the `Activity` class.

Now in the class that extends `AnimActivity`, just set the method `setRightActivity()` to set the activity that should appear when you swipe right, or `setLeftActivity()` to set the activity that should appear when you swipe left.

If you want nothing to happen when you swipe, left or right, just don't set the respective method.
  