### PR TITLE
Make active content be the first on the apps by context list

### DIFF
--- a/app/src/main/java/corp/kairos/adamastor/ContextList/ContextListActivity.java
+++ b/app/src/main/java/corp/kairos/adamastor/ContextList/ContextListActivity.java
@@ -1,24 +1,23 @@
 package corp.kairos.adamastor.ContextList;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.view.View;
 
 import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import corp.kairos.adamastor.Animation.AnimationActivity;
 import corp.kairos.adamastor.Home.HomeActivity;
 import corp.kairos.adamastor.R;
-import corp.kairos.adamastor.Settings.ContextRelated.EditContextAppsActivity;
 import corp.kairos.adamastor.Settings.Settings;
 import corp.kairos.adamastor.UserContext;
 import io.github.luizgrp.sectionedrecyclerviewadapter.SectionedRecyclerViewAdapter;
 
 public class ContextListActivity extends AnimationActivity {
     public static int NUMBER_OF_COLUMNS = 4;
-    private UserContext[] userContexts;
     private RecyclerView mRecyclerView;
     public SectionedRecyclerViewAdapter mAdapter;
 
@@ -30,27 +29,26 @@ public class ContextListActivity extends AnimationActivity {
 
         // Load Contexts from Settings
         Settings settings = Settings.getInstance(getApplicationContext());
-        userContexts = ArrayUtils.addAll(settings.getUserContextsAsArray(), settings.getZeroContext());
+
+        List<UserContext> userContexts = settings.getOrderedUserContexts();
 
         // Set side activities
         super.setAnimation("left");
         super.setLeftActivity(HomeActivity.class);
 
-        setupViews();
+        setupViews(userContexts);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        setupViews();
     }
 
-    private void setupViews() {
+    private void setupViews(List<UserContext> userContexts) {
         mAdapter = new SectionedRecyclerViewAdapter();
-        // TODO: Reorder contexts by active first
         // TODO: Reorder apps by most relevant first
-        for (int i = 0; i < userContexts.length; i++) {
-            UserContext aContext = userContexts[i];
+        for (int i = 0; i < userContexts.size(); i++) {
+            UserContext aContext = userContexts.get(i);
             if (aContext.getContextApps().size() > 0)
                 mAdapter.addSection(
                     new ContextSection(
@@ -58,7 +56,7 @@ public class ContextListActivity extends AnimationActivity {
                         this.mAdapter,
                         aContext.getContextName(),
                         aContext.getContextApps(),
-                        (i == 0 || i == userContexts.length-1)
+                        (i == 0 || i == userContexts.size()-1)
                     )
                 );
         }

--- a/app/src/main/java/corp/kairos/adamastor/Home/HomeActivity.java
+++ b/app/src/main/java/corp/kairos/adamastor/Home/HomeActivity.java
@@ -147,7 +147,6 @@ public class HomeActivity extends AnimationCompatActivity {
     }
 
     private void setupContextDisplayer() {
-        // TODO: Make this method get last active context
         this.userContexts = userSettings.getUserContextsAsArray();
 
         setupViewPager();
@@ -183,10 +182,6 @@ public class HomeActivity extends AnimationCompatActivity {
         }
 
         addTabEventListener(this.tabLayout);
-        // TODO: Set last active context
-        // TODO: Substitute for the persisted
-        int starterBackground = getSelectedTabBackground(this.tabLayout.getTabAt(0));
-        BackgroundChanger.changeWallpaper(getApplicationContext(), starterBackground);
     }
 
     private void addTabEventListener(TabLayout tabLayout) {

--- a/app/src/main/java/corp/kairos/adamastor/Settings/Settings.java
+++ b/app/src/main/java/corp/kairos/adamastor/Settings/Settings.java
@@ -5,16 +5,15 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Build;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 
 import corp.kairos.adamastor.AppDetails;
 import corp.kairos.adamastor.AppsManager.AppsManager;
@@ -188,32 +187,33 @@ public class Settings {
         int context = CollectorService.getInstance().getPredictedContext();
         String result;
         switch(context){
-            case 1: result = "Leisure";
-                    break;
-            case 2: result = "Commute";
-                    break;
-            case 3: result = "Work";
-                    break;
-            default: result = "Leisure";
-                    break;
+            case 2:
+                result = "Commute";
+                break;
+            case 3:
+                result = "Work";
+                break;
+            case 1:
+            default:
+                result = "Leisure";
         }
 
         return result;
     }
 
     public void informCollectorContextChange(String contextName){
-
-        int context = 1;
+        int context;
 
         switch(contextName){
-            case "Leisure": context = 1;
+            case "Commute":
+                context = 2;
                 break;
-            case "Commute": context = 2;
+            case "Work":
+                context = 3;
                 break;
-            case "Work": context = 3;
-                break;
-            default: context = 1;
-                break;
+            case "Leisure":
+            default:
+                context = 1;
         }
 
         CollectorService.getInstance().userContextChange(context);
@@ -258,6 +258,25 @@ public class Settings {
 
     public UserContext getStartingContext(){
         return this.contexts.get("Home");
+    }
+
+    public List<UserContext> getOrderedUserContexts() {
+        List<UserContext>  userContextList = new ArrayList<>(4);
+
+        // First the active context
+        String currentContextName = this.getContextNamefromCollector();
+        userContextList.add(this.contexts.get(currentContextName));
+
+        // The remaining contexts
+        Set<String> otherKeys = new HashSet<>(this.contexts.keySet());
+        otherKeys.remove(currentContextName);
+        for (String key : otherKeys)
+            userContextList.add(this.contexts.get(key));
+
+        // The context containing apps that aren't in any context
+        userContextList.add(this.getZeroContext());
+
+        return userContextList;
     }
 }
 


### PR DESCRIPTION
This PR addresses the following item on issue #50: The contexts display order (bottom to top) should be by what context is currently active first.